### PR TITLE
fix keepalive_opt portable problem under Mac OS

### DIFF
--- a/clients.py
+++ b/clients.py
@@ -4,13 +4,17 @@ import socket
 class RedisMQClient:
     """Redis message queue client"""
 
-    _keepalive_opt = {
-        socket.TCP_KEEPIDLE: 60,
-        socket.TCP_KEEPCNT: 3,
-        socket.TCP_KEEPINTVL: 60,
-    }
+    _keepalive_opt = {}
 
     def __init__(self, **conf):
+        #option may not be portable
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            self._keepalive_opt[socket.TCP_KEEPIDLE] = 60
+        if hasattr(socket, "TCP_KEEPCNT"):
+            self._keepalive_opt[socket.TCP_KEEPCNT] = 3
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            self._keepalive_opt[socket.TCP_KEEPINTVL] = 60
+
         _conf = {
             "socket_timeout": 30,
             "socket_connect_timeout": 15,


### PR DESCRIPTION
Mac OS X or Windows may not have corresponding socket options in python.
Fixing it by optional setting them. 